### PR TITLE
add support for windowless SSG builds

### DIFF
--- a/src/scripts/Main.js
+++ b/src/scripts/Main.js
@@ -11,6 +11,8 @@ export default class {
     }
 
     init() {
+		if (typeof window === 'undefined') return;
+		
         if (!this.smoothMobile) {
             this.isMobile = (/Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent));
         }


### PR DESCRIPTION
When building sites for static site generators, during the build `window` and `document` do not exist and return errors. This simple check suffices for a succesful build.