### PR TITLE
Fixed bug with nested for() loop affecting parent loop index variable used as scroll element ID.

### DIFF
--- a/src/scripts/Native.js
+++ b/src/scripts/Native.js
@@ -42,7 +42,7 @@ export default class extends Core {
         this.els = [];
         const els = this.el.querySelectorAll('[data-'+this.name+']');
 
-        els.forEach((el, i) => {
+        els.forEach((el, id) => {
             let cl = el.dataset[this.name + 'Class'] || this.class;
             let top = el.getBoundingClientRect().top + this.instance.scroll.y;
             let bottom = top + el.offsetHeight;
@@ -75,7 +75,7 @@ export default class extends Core {
 
             const mappedEl = {
                 el: el,
-                id: i,
+                id: id,
                 class: cl,
                 top: top + relativeOffset[0],
                 bottom: bottom - relativeOffset[1],

--- a/src/scripts/Smooth.js
+++ b/src/scripts/Smooth.js
@@ -315,7 +315,7 @@ export default class extends Core {
         this.sections.forEach((section, y) => {
             const els = this.sections[y].el.querySelectorAll(`[data-${this.name}]`);
 
-            els.forEach((el, i) => {
+            els.forEach((el, id) => {
                 let cl = el.dataset[this.name + 'Class'] || this.class;
                 let top;
                 let repeat = el.dataset[this.name + 'Repeat'];
@@ -378,7 +378,7 @@ export default class extends Core {
 
                 const mappedEl = {
                     el,
-                    id: i,
+                    id: id,
                     class: cl,
                     top: top + relativeOffset[0],
                     middle,


### PR DESCRIPTION
Hello,

Quick fix for a bug introduced in this commit : 

https://github.com/thetoine/locomotive-scroll/commit/6d72f9bedce8d8c917347b66047839526889202a#diff-293ef6a89f475cd747eebe98d728a6adR351

```js
for (var i = 0; i < offset.length; i++) {
```

The nested for() loop affect the parent loop `i`, resulting all element with the same id `2`. Check console output below.

![image](https://user-images.githubusercontent.com/1877/75043743-87e14c80-548e-11ea-8b21-7ab126a249de.png)

Thanks!
