### PR TITLE
fix : getTranslate case of matrix3d

### DIFF
--- a/src/scripts/utils/transform.js
+++ b/src/scripts/utils/transform.js
@@ -12,11 +12,13 @@ export function getTranslate(el) {
     const transform = style.transform || style.webkitTransform || style.mozTransform;
 
     let mat = transform.match(/^matrix3d\((.+)\)$/);
-    if(mat) return parseFloat(mat[1].split(', ')[13]);
-
-    mat = transform.match(/^matrix\((.+)\)$/);
-    translate.x = mat ? parseFloat(mat[1].split(', ')[4]) : 0;
-    translate.y = mat ? parseFloat(mat[1].split(', ')[5]) : 0;
-
+    if (mat) {
+        translate.x = mat ? parseFloat(mat[1].split(', ')[12]) : 0;
+        translate.y = mat ? parseFloat(mat[1].split(', ')[13]) : 0;
+    } else{
+        mat = transform.match(/^matrix\((.+)\)$/);
+        translate.x = mat ? parseFloat(mat[1].split(', ')[4]) : 0;
+        translate.y = mat ? parseFloat(mat[1].split(', ')[5]) : 0;
+    }
     return translate;
 }


### PR DESCRIPTION
Situation :In  IE11 browser , act on  ScrollTo() method.  => not work ScrollTo() and DOM hide.

According to my sources, getTranslate return 0 <= not object.

In the case of matrix3d , I thought  return value is probrem.
I fix return value.