### PR TITLE
Handle case where the offset is null 

### DIFF
--- a/src/scripts/Native.js
+++ b/src/scripts/Native.js
@@ -234,13 +234,18 @@ export default class extends Core {
 
         if (callback) {
             offset = offset.toFixed();
-            let onScroll = function () {
-                if (window.pageYOffset.toFixed() === offset) {
-                    window.removeEventListener('scroll', onScroll);
-                    callback();
-                }
-            };
-            window.addEventListener('scroll', onScroll);
+            if (parseInt(offset) === 0) {
+                callback();
+                return;
+            } else {    
+                let onScroll = function () {
+                    if (window.pageYOffset.toFixed() === offset) {
+                        window.removeEventListener('scroll', onScroll);
+                        callback();
+                    }
+                };            
+                window.addEventListener('scroll', onScroll);
+            }
         }
 
         window.scrollTo({


### PR DESCRIPTION
If the offset is equal to 0, the scoll event won't be emitted since the page won't scroll and thus the callback provided to the scrollTo method won't be called.