### PR TITLE
Add support for `duration` option in native mode

### DIFF
--- a/src/scripts/Native.js
+++ b/src/scripts/Native.js
@@ -250,7 +250,7 @@ export default class extends Core {
 
         window.scrollTo({
             top: offset,
-            behavior: 'smooth'
+            behavior: options.duration === 0 ? 'auto' : 'smooth'
         });
     }
 


### PR DESCRIPTION
This add the ability to disable the `smooth` behavior when the scroll duration is set to `0`.

> Related to https://github.com/locomotivemtl/locomotive-scroll/pull/190#issuecomment-828539929