### PR TITLE
Add missing ');' in the code example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ scroll.on('scroll', (args) => {
         // ouput log example: 0.34
         // gsap example : myGsapAnimation.progress(progress);
     }
-}
+});
 ```
 
 


### PR DESCRIPTION
This PR is probably more advanced than #264 because it has a semicolon at the end of the line, and thus preserves the README code style 😄