### PR TITLE
Fix scrolling class applied on `mouseup` event

### DIFF
--- a/src/scripts/Native.js
+++ b/src/scripts/Native.js
@@ -250,7 +250,7 @@ export default class extends Core {
 
         window.scrollTo({
             top: offset,
-            behavior: 'smooth'
+            behavior: options.duration === 0 ? 'auto' : 'smooth'
         });
     }
 

--- a/src/scripts/Smooth.js
+++ b/src/scripts/Smooth.js
@@ -491,7 +491,11 @@ export default class extends Core {
 
     releaseScrollBar(e) {
         this.isDraggingScrollbar = false;
-        this.html.classList.add(this.scrollingClass);
+
+        if (this.isScrolling) {
+            this.html.classList.add(this.scrollingClass);
+        }
+
         this.html.classList.remove(this.draggingClass);
     }
 


### PR DESCRIPTION
This prevent the `has-scroll-scrolling` class to be applied on `documentElement` when a `mouseup` event is fired but there is no scrolling action.