### PR TITLE
Only calculate movement for set scroll direction

### DIFF
--- a/src/scripts/Smooth.js
+++ b/src/scripts/Smooth.js
@@ -505,20 +505,25 @@ export default class extends Core {
     moveScrollBar(e) {
         if (this.isDraggingScrollbar) {
             requestAnimationFrame(() => {
-                let x =
-                    ((((e.clientX - this.scrollbarBCR.left) * 100) / this.scrollbarWidth) *
-                        this.instance.limit.x) /
-                    100;
-                let y =
-                    ((((e.clientY - this.scrollbarBCR.top) * 100) / this.scrollbarHeight) *
-                        this.instance.limit.y) /
-                    100;
-
-                if (y > 0 && y < this.instance.limit.y) {
-                    this.instance.delta.y = y;
+                if (this.direction === 'horizontal') {
+                    let x =
+                        ((((e.clientX - this.scrollbarBCR.left) * 100) / this.scrollbarWidth) *
+                            this.instance.limit.x) /
+                        100;
+                    
+                    if (x > 0 && x < this.instance.limit.x) {
+                        this.instance.delta.x = x;
+                    }
                 }
-                if (x > 0 && x < this.instance.limit.x) {
-                    this.instance.delta.x = x;
+                else {
+                    let y =
+                        ((((e.clientY - this.scrollbarBCR.top) * 100) / this.scrollbarHeight) *
+                            this.instance.limit.y) /
+                        100;
+
+                    if (y > 0 && y < this.instance.limit.y) {
+                        this.instance.delta.y = y;
+                    }
                 }
             });
         }


### PR DESCRIPTION
Before, when used in vertical scrolling, x was always smaller than this.instance.limit.x resulting in the problem described here: https://github.com/locomotivemtl/locomotive-scroll/issues/362
From a performance point of view it is not necessary to do both calculations, as only one scroll direction can apply. Most other function use the same distinction between this.direction === 'horizontal' and 'vertical',