### PR TITLE
docs: fix simple typo, additionnal -> additional

### DIFF
--- a/src/scripts/Native.js
+++ b/src/scripts/Native.js
@@ -193,7 +193,7 @@ export default class extends Core {
      *
      * @param  Available options :
      *          target {node, string, "top", "bottom", int} - The DOM element we want to scroll to
-     *          options {object} - Options object for additionnal settings.
+     *          options {object} - Options object for additional settings.
      * @return {void}
      */
     scrollTo(target, options = {}) {

--- a/src/scripts/Smooth.js
+++ b/src/scripts/Smooth.js
@@ -881,7 +881,7 @@ export default class extends Core {
      *
      * @param  Available options :
      *          target {node, string, "top", "bottom", int} - The DOM element we want to scroll to
-     *          options {object} - Options object for additionnal settings.
+     *          options {object} - Options object for additional settings.
      * @return {void}
      */
     scrollTo(target, options = {}) {


### PR DESCRIPTION
There is a small typo in src/scripts/Native.js, src/scripts/Smooth.js.

Should read `additional` rather than `additionnal`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md