### PR TITLE
fix core instance cleanup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,12 @@ export default class LocomotiveScroll {
         // Destroy Lenis
         this.lenisInstance.destroy();
         // Destroy Core
-        this.coreInstance.destroy();
+        this.coreInstance?.destroy();
+
+        // Ensure a delay before destroying to handle cases of instant destruction
+        requestAnimationFrame(() => {
+            this.coreInstance?.destroy();
+        });
     }
 
     /**


### PR DESCRIPTION
~Defining an `exports` field in `package.json` requires to explicitly declare public exports.~

Also, if you try to `destory()` the locomotive instance on `useEffect` cleanup it throws an error:
```
TypeError: Cannot read properties of undefined (reading 'destroy')
```
It's coming from the core instance's destroy method, which is `undefined` by the time the cleanup runs.

Fix it by calling the `destroy()` method in the next repaint. Not sure if this is the best fix but it Just Works™

Repro: https://codesandbox.io/s/brave-chatelet-8lv3qd
