### PR TITLE
Add support for scroll delay

### DIFF
--- a/src/core/ScrollElement.ts
+++ b/src/core/ScrollElement.ts
@@ -28,7 +28,8 @@ import {
     scrollCallFrom,
     scrollOrientation,
 } from '../types';
-import { clamp, closestNumber, normalize, mapRange } from '../utils/maths';
+import { clamp, closestNumber, normalize, mapRange, lerp } from '../utils/maths';
+import { getTranslate } from '../utils/translate';
 
 /** Constants */
 const INVIEW_CLASS = 'is-inview';
@@ -95,6 +96,10 @@ export default class ScrollElement {
             scrollSpeed:
                 this.$el.dataset['scrollSpeed'] != null
                     ? parseFloat(this.$el.dataset['scrollSpeed'])
+                    : null,
+            scrollDelay:
+                this.$el.dataset['scrollDelay'] != null
+                    ? parseFloat(this.$el.dataset['scrollDelay'])
                     : null,
             scrollRepeat: this.$el.dataset['scrollRepeat'] != null,
             scrollCall: this.$el.dataset['scrollCall'] ?? null,
@@ -205,10 +210,23 @@ export default class ScrollElement {
                         progress * wSize * this.attributes.scrollSpeed * -1;
                 }
 
-                this.$el.style.transform =
-                    this.scrollOrientation === 'vertical'
-                        ? `translate3d(0, ${this.translateValue}px, 0)`
-                        : `translate3d(${this.translateValue}px, 0, 0)`;
+                if (this.attributes.scrollDelay) {
+                    const start = getTranslate(this.$el)
+                    const lerped = this.scrollOrientation == 'vertical' ?
+                        lerp(start.x, this.translateValue, this.attributes.scrollDelay) :
+                        lerp(start.y, this.translateValue, this.attributes.scrollDelay)
+
+                    this.$el.style.transform =
+                        this.scrollOrientation === 'vertical'
+                            ? `translate3d(0, ${lerped}px, 0)`
+                            : `translate3d(${lerped}px, 0, 0)`;
+                }
+                else {
+                    this.$el.style.transform =
+                        this.scrollOrientation === 'vertical'
+                            ? `translate3d(0, ${this.translateValue}px, 0)`
+                            : `translate3d(${this.translateValue}px, 0, 0)`;
+                }
             }
         }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,6 +189,7 @@ export interface IScrollElementOptions {
  */
 export interface IScrollElementAttributes {
     scrollClass: string;
+    scrollDelay: number | null;
     scrollOffset: string;
     scrollPosition: string;
     scrollModuleProgress: boolean;

--- a/src/utils/maths.ts
+++ b/src/utils/maths.ts
@@ -62,3 +62,15 @@ export function closestNumber(array: number[], target: number): number {
         return Math.abs(curr - target) < Math.abs(prev - target) ? curr : prev;
     });
 }
+
+
+/**
+ * Linear interpolation between two numbers.
+ * @param {number} start 
+ * @param {number} end 
+ * @param {number} amt 
+ * @returns {number}
+ */
+export function lerp(start: number, end: number, amt: number): number {
+    return (1 - amt) * start + amt * end;
+}

--- a/src/utils/translate.ts
+++ b/src/utils/translate.ts
@@ -1,0 +1,18 @@
+export function getTranslate(el: Element) {
+    const translate = {x: 0, y: 0};
+
+    if (!window.getComputedStyle) return translate;
+
+    const style = getComputedStyle(el);
+    const transform = style.transform  
+
+    let matches = transform.match(/translate\(([^)]+)\)/);
+
+    if (matches) {
+        const parts = matches[1].split(', ');
+        translate.x = parseFloat(parts[0]);
+        translate.y = parseFloat(parts[1]);
+    }
+
+    return translate;
+}


### PR DESCRIPTION
This pull request adds support for scroll delay in locomotive-scroll v5.  The `data-scroll-delay` attribute can be set on the element to control the delay duration. If the attribute is not set, the element will scroll without delay. 