### PR TITLE
Update TypeScript declaration file export path

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "types": "dist/types/index.d.ts",
     "exports": {
         ".": {
-            "types": "./dist/locomotive-scroll.d.ts",
+            "types": "./dist/types/index.d.ts",
             "require": "./dist/locomotive-scroll.js",
             "default": "./dist/locomotive-scroll.modern.mjs"
         },


### PR DESCRIPTION
Updated the export path for TypeScript declaration file in the 'exports' field of package.json from './dist/locomotive-scroll.d.ts' to './dist/types/index.d.ts'. This change ensures that TypeScript can properly locate the declaration file for 'locomotive-scroll', resolving potential type declaration issues.