### PR TITLE
Fix lenis github url in docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Find more ways to install the package in our [Quick start](https://scroll.locomo
 
 | Name                        | Support | Description                                                                                                      |
 | --------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------- |
-| Lenis                       | ✅      | Built on top of [Lenis](https://github.com/studio-freight/lenis).                       |
+| Lenis                       | ✅      | Built on top of [Lenis](https://github.com/darkroomengineering/lenis).                       |
 | TypeScript                  | ✅      | For a better developer experience                                                                                |
 | Built-in viewport detection | ✅      | Using browsers's native Intersection Observer API                                                                |
 | Real time progress value    | ✅      | For flexible scroll-based animation                                                                              |
@@ -34,10 +34,10 @@ Find more ways to install the package in our [Quick start](https://scroll.locomo
 
 | Name                                             | Description                  |
 | ------------------------------------------------ | ---------------------------- |
-| [Lenis](https://github.com/studio-freight/lenis) | How smooth scroll should be. |
+| [Lenis](https://github.com/darkroomengineering/lenis) | How smooth scroll should be. |
 
 ## Related
 
--   [Lenis](https://github.com/studio-freight/lenis)
+-   [Lenis](https://github.com/darkroomengineering/lenis)
 -   [Modularjs](https://github.com/modularorg/modularjs)
 -   [Locomotive Boilerplate 🚂](https://github.com/locomotivemtl/locomotive-boilerplate)

--- a/www/docs/README.md
+++ b/www/docs/README.md
@@ -22,7 +22,7 @@ See the [Quick start](quickstart.md) guide for more details.
 
 | Name                        | Support | Description                                                                                                      |
 | --------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------- |
-| Lenis                       | ✅      | Built on top of [Lenis](https://github.com/studio-freight/lenis) |
+| Lenis                       | ✅      | Built on top of [Lenis](https://github.com/darkroomengineering/lenis) |
 | TypeScript                  | ✅      | For a better developer experience                                                                                |
 | Built-in viewport detection | ✅      | Using browsers's native Intersection Observer API                                                                |
 | Real time progress value    | ✅      | For flexible scroll-based animation                                                                              |
@@ -37,10 +37,10 @@ Check out the [Examples](playground.md) to see locomotive-scroll in use.
 
 | Name                                             | Description                  |
 | ------------------------------------------------ | ---------------------------- |
-| [Lenis](https://github.com/studio-freight/lenis) | How smooth scroll should be. |
+| [Lenis](https://github.com/darkroomengineering/lenis) | How smooth scroll should be. |
 
 ## Related
 
--   [Lenis](https://github.com/studio-freight/lenis)
+-   [Lenis](https://github.com/darkroomengineering/lenis)
 -   [Modularjs](https://github.com/modularorg/modularjs)
 -   [Locomotive Boilerplate 🚂](https://github.com/locomotivemtl/locomotive-boilerplate)

--- a/www/docs/limitations.md
+++ b/www/docs/limitations.md
@@ -4,7 +4,7 @@
 
 ## Lenis
 
-Lenis already have its own [considerations](https://github.com/studio-freight/lenis#considerations). We recommend reviewing them before using Locomotive Scroll to ensure a smooth integration and avoid any potential conflicts. 
+Lenis already have its own [considerations](https://github.com/darkroomengineering/lenis#considerations). We recommend reviewing them before using Locomotive Scroll to ensure a smooth integration and avoid any potential conflicts. 
 
 There are certain Lenis `options` that are not supported in the Locomotive Scroll layer :
 
@@ -16,7 +16,7 @@ Due to Locomotive Scroll's reliance on the window reference and Intersection Obs
 
 ## Third Party Injected Popups
 
-Some third-party JavaScript used on websites may inject popups or modals that require scrolling. In certain cases, conflicts can arise when the default Lenis `wrapper` (typically the `window`) captures the scroll event. Normally, we can [resolve this](https://github.com/studio-freight/lenis#use-the-data-lenis-prevent-attribute-on-nested-scroll-elements-in-addition-we-advise-you-to-add-overscroll-behavior-contain-on-this-element) by adding the `data-lenis-prevent` data attribute to the DOM element that requires inner scrolling, such as a popup. However, this solution cannot be used when the DOM is injected dynamically. 
+Some third-party JavaScript used on websites may inject popups or modals that require scrolling. In certain cases, conflicts can arise when the default Lenis `wrapper` (typically the `window`) captures the scroll event. Normally, we can [resolve this](https://github.com/darkroomengineering/lenis#use-the-data-lenis-prevent-attribute-on-nested-scroll-elements-in-addition-we-advise-you-to-add-overscroll-behavior-contain-on-this-element) by adding the `data-lenis-prevent` data attribute to the DOM element that requires inner scrolling, such as a popup. However, this solution cannot be used when the DOM is injected dynamically. 
 
 To address this issue, we have found a workaround. Here's how it works:
 

--- a/www/docs/methods.md
+++ b/www/docs/methods.md
@@ -89,7 +89,7 @@ The `scrollTo(target, options)` method allows you to scroll to a specific target
 
 -   **Parameters:**
     -   `target` (_optional, number / HTMLElement / string_): The target to scroll to. It can be a `number` (scroll position), `HTMLElement` (DOM element), or `string` (CSS selector or keyword: `top`, `left`, `start`, `bottom`, `right`, `end`).
-    -   `options` (_optional, ILenisScrollToOptions_): An options object that configures the scroll behavior. The available options are based on [Lenis's scroll-to options](https://github.com/studio-freight/lenis#instance-methods):
+    -   `options` (_optional, ILenisScrollToOptions_): An options object that configures the scroll behavior. The available options are based on [Lenis's scroll-to options](https://github.com/darkroomengineering/lenis#instance-methods):
         -   `offset` (_number_): A number equivalent to `scroll-padding-top`. Specifies the offset from the top of the target element.
         -   `lerp` (_number_): Animation lerp intensity.
         -   `duration` (_number_): The duration of the scroll animation in seconds.

--- a/www/docs/options.md
+++ b/www/docs/options.md
@@ -4,7 +4,7 @@
 
 -   **Type:** `object`
 
-_(Optional)_ The `lenisOptions` parameter is an optional object that allows you to configure specific settings based on some of [Lenis's instance settings](https://github.com/studio-freight/lenis#instance-settings):
+_(Optional)_ The `lenisOptions` parameter is an optional object that allows you to configure specific settings based on some of [Lenis's instance settings](https://github.com/darkroomengineering/lenis#instance-settings):
 
 -   `wrapper` (**HTMLElement|Window**): Specifies the element that will be used as the scroll container.
 -   `content` (**HTMLElement**): Specifies the element that contains the content that will be scrolled, usually `wrapper`'s direct child.

--- a/www/docs/quickstart.md
+++ b/www/docs/quickstart.md
@@ -51,7 +51,7 @@ Add the base styles to your CSS file.
 
 [locomotive-scroll.css](https://github.com/locomotivemtl/locomotive-scroll/blob/v5-beta/bundled/locomotive-scroll.css)
 
-Learn more about styling considerations on [Lenis documentation](https://github.com/studio-freight/lenis#considerations).
+Learn more about styling considerations on [Lenis documentation](https://github.com/darkroomengineering/lenis#considerations).
 
 #### Sass Import
 


### PR DESCRIPTION
It seems like lenis has moved from studio-freight to darkroomengineering and docs are outdated.

This is a simple search-and-replace in README and www/docs.